### PR TITLE
Work around toString call failing in EL

### DIFF
--- a/diachron-archive/archive-web-services/src/main/webapp/WEB-INF/uiviews/apidoc.jsp
+++ b/diachron-archive/archive-web-services/src/main/webapp/WEB-INF/uiviews/apidoc.jsp
@@ -10,8 +10,9 @@
 				<li>'query'    : The URL-encoded query string expressed in SPARQL</li>
 				<li>'queryType : The query type (e.g. 'CONSTRUCT' or 'SELECT')</li>  
 			</ul>
+                        <c:set var="url">${pageContext.request.requestURL}</c:set>
 			<c:set var="baseURL" 
-				value="${fn:replace(pageContext.request.requestURL[toString](), pageContext.request.requestURI, pageContext.request.contextPath)}" />
+				value="${fn:replace(url, pageContext.request.requestURI, pageContext.request.contextPath)}" />
 			
 			<p>Example request: <br/>
 			<a target="_blank" href="${baseURL}/archive?query=CONSTRUCT%20{?dataset%20?p%20?o}%20FROM%20&lt;efo-datasets-v3&gt;%20WHERE%20{?dataset%20a%20diachron:Dataset%20;%20?p%20?o}&queryType=CONSTRUCT">


### PR DESCRIPTION
The toString call embedded in EL is failing on at least some versions of
JSP/JSTL; this works around that problem.

Fixes diachron/archive#3